### PR TITLE
Remove colons

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,9 @@
-# Version: 1.0.2
+# Version 1.0.2
   * Feature: Ensure files end with a line break
   * Feature: Build pkgs and set ENV variables
   * Feature: Add tests for yml parsing
   
-# Version: 1.0.1
+# Version 1.0.1
   * Breaking changes
   * Feature: use `rcmdcheck` instead of `devtools`. This breaks/changes a few things.
   * Feature: `check_via_env()` now has arguments


### PR DESCRIPTION
`pkgdown` will not parse version entries with colons in the name