### PR TITLE
Stop lint_package checking renv

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,15 +1,15 @@
 Type: Package
 Package: inteRgrate
 Title: Opinionated Package Coding Styles
-Version: 1.0.9
-Authors@R: 
+Version: 1.0.10
+Authors@R:
     person(given = "Jumping",
            family = "Rivers",
            role = c("aut", "cre"),
            email = "info@jumpingrivers.com")
-Description: A set of functions to enforce styling in functions.
-    This package would typically be used in with a CI platform, such as
-    GitHub and GitLab.
+Description: A set of functions to enforce styling in functions.  This
+    package would typically be used in with a CI platform, such as GitHub
+    and GitLab.
 License: GPL-2 | GPL-3
 Imports:
     cli,
@@ -20,9 +20,9 @@ Imports:
     stringr,
     tibble,
     usethis
-Suggests: 
+Suggests:
     roxygen2,
     testthat
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# inteRgrate 1.0.10 _2021-03-11_
+  * Bug: don't lint renv or packrat folders
+
 # inteRgrate 1.0.9 _2021-01-22_
   * Bug: multiple pkgs in a repo
 

--- a/R/check_lintr.R
+++ b/R/check_lintr.R
@@ -16,7 +16,7 @@ get_exclusions = function() {
 
 lint_files = function() {
   lint_errors = FALSE
-  lints = lintr::lint_package()
+  lints = lintr::lint_package(list("R/RcppExports.R", "renv", "packrat"))
   if (length(lints) > 0) {
     lapply(lints, print)
     lint_errors = TRUE


### PR DESCRIPTION
`check_lint()` uses `lint_package()` to run the linting test. 

I think we should exclude any `renv/` and `packrat/` folders from this test as default. 

There was a discussion about this on a [{lintr} issue ](https://github.com/jimhester/lintr/issues/697) about this.

{lintr} has since added this as default to `lint_dir()` but not `lint_package()` as they argue there is no need for {packrat}/{renv} within an R package. However, for our shiny app in a package workflow - I think there is an argument for using {renv}

Options:

1. Set exclusions when {inteRgrate} calls `lint_package()` see 294e73828fe2688258db442f0c9f9ec6c0b1cfd0
2. Use `lint_dir()` instead of `lint_package()`
3. Argue the case to {lintr} that these exclusions should be default for `lint_package()` as well as `lint_dir()`
4. Something else?

 