### PR TITLE
Fix description tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: inteRgrate
 Title: Opinionated Package Coding Styles
-Version: 1.0.20
+Version: 1.0.21
 Authors@R:
     person("Jumping", "Rivers", , "info@jumpingrivers.com", role = c("aut", "cre"))
 Description: A set of functions to enforce styling in functions.  This

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,8 @@ Imports:
     usethis
 Suggests:
     roxygen2,
-    testthat
+    testthat,
+    withr
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,10 +3,7 @@ Package: inteRgrate
 Title: Opinionated Package Coding Styles
 Version: 1.0.20
 Authors@R:
-    person(given = "Jumping",
-           family = "Rivers",
-           role = c("aut", "cre"),
-           email = "info@jumpingrivers.com")
+    person("Jumping", "Rivers", , "info@jumpingrivers.com", role = c("aut", "cre"))
 Description: A set of functions to enforce styling in functions.  This
     package would typically be used in with a CI platform, such as GitHub
     and GitLab.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# inteRgrate 1.0.21 _2022-02-22_
+  * Ensure Authors@R field is tidy in tests on `check_tidy_description()`
+    - See [https://github.com/r-lib/desc/issues/78]()
+
 # inteRgrate 1.0.20 _2021-10-04_
   * Default branch for getting repo is now `main`
 

--- a/inst/test_news/DESCRIPTION-dev
+++ b/inst/test_news/DESCRIPTION-dev
@@ -3,10 +3,7 @@ Package: inteRgrate
 Title: Opinionated Package Coding Styles
 Version: 1.0.2.9001
 Authors@R:
-    person(given = "Jumping",
-           family = "Rivers",
-           role = c("aut", "cre"),
-           email = "info@jumpingrivers.com")
+    person("Jumping", "Rivers", , "info@jumpingrivers.com", role = c("aut", "cre"))
 Description: A set of functions to enforce styling in functions.  This
     package would typically be used in with a CI platform, such as GitHub
     and GitLab.

--- a/inst/test_news/DESCRIPTION-major
+++ b/inst/test_news/DESCRIPTION-major
@@ -3,10 +3,7 @@ Package: inteRgrate
 Title: Opinionated Package Coding Styles
 Version: 1.0.2
 Authors@R: 
-    person(given = "Jumping",
-           family = "Rivers",
-           role = c("aut", "cre"),
-           email = "info@jumpingrivers.com")
+    person("Jumping", "Rivers", , "info@jumpingrivers.com", role = c("aut", "cre"))
 Description: A set of functions to enforce styling in functions.  This
     package would typically be used in with a CI platform, such as GitHub
     and GitLab.

--- a/tests/testthat/test_tidy_description.R
+++ b/tests/testthat/test_tidy_description.R
@@ -3,12 +3,17 @@ test_that("Testing tidy description", {
   ## Hard to test, as use_tidy_description looks at the current .Rproj
   ## XXX: Could create a dummy .Rproj file?
 
-  description = file.path(system.file("test_news", package = "inteRgrate"), "DESCRIPTION-major")
-  file.copy(description, to = "DESCRIPTION", overwrite = TRUE)
-  expect_null(check_tidy_description())
-  description = file.path(system.file("test_news", package = "inteRgrate"), "DESCRIPTION-dev")
-  file.copy(description, to = "DESCRIPTION", overwrite = TRUE)
-  expect_null(check_tidy_description())
+  withr::with_dir(
+    tempdir(), {
+      description = file.path(system.file("test_news", package = "inteRgrate"), "DESCRIPTION-major")
+      file.copy(description, to = "DESCRIPTION", overwrite = TRUE)
+      expect_null(check_tidy_description())
+  })
 
-
+  withr::with_dir(
+    tempdir(), {
+      description = file.path(system.file("test_news", package = "inteRgrate"), "DESCRIPTION-dev")
+      file.copy(description, to = "DESCRIPTION", overwrite = TRUE)
+      expect_null(check_tidy_description())
+  })
 })


### PR DESCRIPTION
CI was failing, because tests on `check_tidy_description()` were failing.

Following https://github.com/r-lib/desc/issues/78 / https://github.com/r-lib/desc/commit/d28bcf94966db4607ee365d52d4822e7f8c7bc05

- person() entries in the Authors@R field are in one-line format after running `usethis::use_tidy_description()`
- these entries were in multiline format in those DESCRIPTION files that underpin the `check_tidy_description()` tests
- those test entries were updated to match the new format output by {desc} / {usethis} on tidying a DESCRIPTION

Also,
the tests for `check_test_description()` were pretty dangerous. Now the test DESCRIPTION files are copied into a temp directory before running check_test_description() inside that temp directory.